### PR TITLE
Checkbox fix

### DIFF
--- a/classes/elements/WP_Form_Element_Checkboxes.php
+++ b/classes/elements/WP_Form_Element_Checkboxes.php
@@ -3,4 +3,11 @@
 class WP_Form_Element_Checkboxes extends WP_Form_Element_Multiple {
 	protected $type = 'checkboxes';
 	protected $default_view = 'WP_Form_View_Checkboxes';
+
+	public function get_selected() {
+		if ( !empty($this->value) ) {
+			return $this->value;
+		}
+		return $this->default_value;
+	}
 }

--- a/classes/views/WP_Form_View_Checkboxes.php
+++ b/classes/views/WP_Form_View_Checkboxes.php
@@ -7,11 +7,11 @@ class WP_Form_View_Checkboxes extends WP_Form_View {
 			throw new LogicException(__('Cannot render checkbox group without a name', 'wp-forms'));
 		}
 		$options = $element->get_options();
-		$selected = $element->get_selected();
+		$selected = (array) $element->get_selected();
 		$output = '';
 		foreach ( $options as $key => $label ) {
 			$checked = false;
-			if ( is_array( $selected ) && in_array( $key, $selected ) ) {
+			if ( in_array( $key, $selected ) ) {
 				$checked = true;
 			}
 			$output .= $this->checkbox( $key, $label, $attributes, $checked );

--- a/classes/views/WP_Form_View_Checkboxes.php
+++ b/classes/views/WP_Form_View_Checkboxes.php
@@ -7,14 +7,19 @@ class WP_Form_View_Checkboxes extends WP_Form_View {
 			throw new LogicException(__('Cannot render checkbox group without a name', 'wp-forms'));
 		}
 		$options = $element->get_options();
+		$selected = $element->get_selected();
 		$output = '';
 		foreach ( $options as $key => $label ) {
-			$output .= $this->checkbox( $key, $label, $attributes );
+			$checked = false;
+			if ( is_array( $selected ) && in_array( $key, $selected ) ) {
+				$checked = true;
+			}
+			$output .= $this->checkbox( $key, $label, $attributes, $checked );
 		}
 		return $output;
 	}
 
-	protected function checkbox( $key, $label, $attributes ) {
+	protected function checkbox( $key, $label, $attributes, $checked ) {
 		$checkbox = WP_Form_Element::create('checkbox')
 			->set_name($attributes['name'].'[]')
 			->set_label($label)
@@ -31,6 +36,9 @@ class WP_Form_View_Checkboxes extends WP_Form_View {
 		}
 		foreach ( $attributes as $att => $value ) {
 			$checkbox->set_attribute($att, $value);
+		}
+		if ( $checked ) {
+			$checkbox->set_attribute('checked', 'checked');
 		}
 		return $checkbox->render();
 	}


### PR DESCRIPTION
Allow either an array of values or a single value to be passed to WP_Form_Element::set_default_value to set a 'checked' state for the checkboxes form element.
