### PR TITLE
New form element & updated errors decorator

### DIFF
--- a/classes/WP_Form.php
+++ b/classes/WP_Form.php
@@ -74,6 +74,71 @@ class WP_Form implements WP_Form_Aggregate, WP_Form_Attributes_Interface {
 		return $this;
 	}
 
+	public function get_elements_as_array() {
+		$result = array();
+
+		$result = $this->get_elements_as_array_prepare( $this->elements );
+
+		return $result;
+	}
+
+	public function get_elements_as_array_prepare( array $elements ) {
+		$result = array();
+
+		foreach( $elements as $name => $element ) {
+			if( $element instanceof WP_Form_Aggregate ) {
+				//foreach( $element->get_children() as $child ) {
+				$result[$name]['elements'] = $this->get_elements_as_array_prepare( $element->get_children() );
+				//}
+			}
+
+			$result[$name]['priority'] = $element->get_priority();
+			$result[$name]['label'] = $element->get_label();
+			$result[$name]['description'] = $element->get_description();
+			$result[$name]['attributes'] = $element->get_all_attributes();
+		}
+
+
+
+
+
+
+
+
+
+
+
+
+		/*$result['priority'] = $element->get_priority();
+		$result['label'] = $element->get_label();
+		$result['description'] = $element->get_description();
+		$result['attributes'] = $element->get_all_attributes();*/
+
+		//$empty_or = empty( $element->elements );
+		//$array_or = is_array( $element->elements );
+
+		/*if( !empty( $element->elements ) && is_array( $element->elements ) ) {
+			foreach( $element->elements as $inner_name => $inner_element ) {
+				$result['elements'][$inner_name] = $this->get_element_as_array( $inner_element );
+			}
+		}*/
+
+		/*if( $element instanceof WP_Form_Aggregate ) {
+			foreach ( $element->get_children() as $child ) {
+				$this->prepare_form_values( $child );
+			}
+		}*/
+
+		/*if( $element instanceof WP_Form_Aggregate ) {
+			foreach( $element->get_children() as $child) {
+				$child;
+				$result[$name]['elements'][] = $this->get_element_as_array( $child );
+			}
+		}*/
+
+		return $result;
+	}
+
 	/**
 	 * @param $key
 	 * @return null|WP_Form_Component

--- a/classes/WP_Form.php
+++ b/classes/WP_Form.php
@@ -75,10 +75,7 @@ class WP_Form implements WP_Form_Aggregate, WP_Form_Attributes_Interface {
 	}
 
 	public function get_elements_as_array() {
-		$result = array();
-
-		$result = $this->get_elements_as_array_prepare( $this->elements );
-
+		$result = (array)$this->get_elements_as_array_prepare( $this->elements );
 		return $result;
 	}
 

--- a/classes/WP_Form.php
+++ b/classes/WP_Form.php
@@ -97,45 +97,6 @@ class WP_Form implements WP_Form_Aggregate, WP_Form_Attributes_Interface {
 			$result[$i]['description'] = $elements[$i]->get_description();
 			$result[$i]['attributes'] = $elements[$i]->get_all_attributes();
 		}
-
-
-
-
-
-
-
-
-
-
-
-
-		/*$result['priority'] = $element->get_priority();
-		$result['label'] = $element->get_label();
-		$result['description'] = $element->get_description();
-		$result['attributes'] = $element->get_all_attributes();*/
-
-		//$empty_or = empty( $element->elements );
-		//$array_or = is_array( $element->elements );
-
-		/*if( !empty( $element->elements ) && is_array( $element->elements ) ) {
-			foreach( $element->elements as $inner_name => $inner_element ) {
-				$result['elements'][$inner_name] = $this->get_element_as_array( $inner_element );
-			}
-		}*/
-
-		/*if( $element instanceof WP_Form_Aggregate ) {
-			foreach ( $element->get_children() as $child ) {
-				$this->prepare_form_values( $child );
-			}
-		}*/
-
-		/*if( $element instanceof WP_Form_Aggregate ) {
-			foreach( $element->get_children() as $child) {
-				$child;
-				$result[$name]['elements'][] = $this->get_element_as_array( $child );
-			}
-		}*/
-
 		return $result;
 	}
 

--- a/classes/WP_Form.php
+++ b/classes/WP_Form.php
@@ -83,19 +83,19 @@ class WP_Form implements WP_Form_Aggregate, WP_Form_Attributes_Interface {
 	}
 
 	public function get_elements_as_array_prepare( array $elements ) {
+		$elements = array_values( $elements );
 		$result = array();
 
-		foreach( $elements as $name => $element ) {
-			if( $element instanceof WP_Form_Aggregate ) {
-				//foreach( $element->get_children() as $child ) {
-				$result[$name]['elements'] = $this->get_elements_as_array_prepare( $element->get_children() );
-				//}
+		$number_of = count( $elements );
+		for( $i = 0; $i < $number_of; $i++ ) {
+			if( $elements[$i] instanceof WP_Form_Aggregate ) {
+				$result[$i]['elements'] = $this->get_elements_as_array_prepare( $elements[$i]->get_children() );
 			}
 
-			$result[$name]['priority'] = $element->get_priority();
-			$result[$name]['label'] = $element->get_label();
-			$result[$name]['description'] = $element->get_description();
-			$result[$name]['attributes'] = $element->get_all_attributes();
+			$result[$i]['priority'] = $elements[$i]->get_priority();
+			$result[$i]['label'] = $elements[$i]->get_label();
+			$result[$i]['description'] = $elements[$i]->get_description();
+			$result[$i]['attributes'] = $elements[$i]->get_all_attributes();
 		}
 
 

--- a/classes/WP_Form.php
+++ b/classes/WP_Form.php
@@ -93,6 +93,7 @@ class WP_Form implements WP_Form_Aggregate, WP_Form_Attributes_Interface {
 			$result[$i]['label'] = $elements[$i]->get_label();
 			$result[$i]['description'] = $elements[$i]->get_description();
 			$result[$i]['attributes'] = $elements[$i]->get_all_attributes();
+			$result[$i]['errors'] = $elements[$i]->get_errors();
 		}
 		return $result;
 	}

--- a/classes/WP_Form_Listener.php
+++ b/classes/WP_Form_Listener.php
@@ -24,6 +24,7 @@ class WP_Form_Listener {
 			return;
 		}
 		$submission->submit();
+		$submission->prepare_form();
 		$submission->redirect();
 	}
 

--- a/classes/WP_Form_Listener.php
+++ b/classes/WP_Form_Listener.php
@@ -6,6 +6,8 @@ class WP_Form_Listener {
 
 	private function add_hooks() {
 		add_action( 'init', array( $this, 'check_form_submission' ), 111, 0 );
+		add_action( 'wp_ajax_wp_forms', array( $this, 'check_form_submission_ajax' ) );
+		add_action( 'wp_ajax_nopriv_wp_forms', array( $this, 'check_form_submission_ajax' ) );
 	}
 
 	public function check_form_submission() {
@@ -23,6 +25,37 @@ class WP_Form_Listener {
 		}
 		$submission->submit();
 		$submission->redirect();
+	}
+
+	/**
+	 * Similar to check_form_submission() but for AJAX requests.
+	 *
+	 * @see check_form_submission()
+	 *
+	 * @throws Exception
+	 */
+	public function check_form_submission_ajax() {
+		$kk = '';
+		if ( empty($_REQUEST['data']['wp_form_id']) || empty($_REQUEST['data']['wp_form_nonce']) ) {
+			return;
+		}
+		if ( !wp_verify_nonce($_REQUEST['data']['wp_form_nonce'], $_REQUEST['data']['wp_form_id']) ) {
+			return;
+		}
+
+		$form = wp_get_form($_REQUEST['data']['wp_form_id']);
+		$submission = new WP_Form_Submission($form, $_REQUEST['data']);
+		if ( !$submission->is_valid() ) {
+			/**
+			 * похоже здесь это не надо вызывать, т к возможно эта штука втыкает ошибки в хтмл,
+			 * а нам нужно просто подготовить ошибки и отправить их
+			 */
+			$submission->prepare_form();
+			$submission->send_ajax_answer();
+			return;
+		}
+		$submission->submit_ajax();
+		$submission->send_ajax_answer();
 	}
 
 	/********** Singleton *************/

--- a/classes/WP_Form_Submission.php
+++ b/classes/WP_Form_Submission.php
@@ -34,7 +34,7 @@ class WP_Form_Submission {
 		}
 	}
 
-	public function sumbit_ajax() {
+	public function submit_ajax() {
 		$this->submit();
 	}
 

--- a/classes/WP_Form_Submission.php
+++ b/classes/WP_Form_Submission.php
@@ -34,6 +34,10 @@ class WP_Form_Submission {
 		}
 	}
 
+	public function sumbit_ajax() {
+		$this->submit();
+	}
+
 	/**
 	 * @param string $key The form element name, as it would be displayed
 	 * in the HTML.
@@ -90,6 +94,23 @@ class WP_Form_Submission {
 	 */
 	public function set_redirect( $url = '' ) {
 		$this->redirect = $url;
+	}
+
+	public function send_ajax_answer() {
+		$kk = '';
+		if ( !$this->is_valid() ) {
+			wp_send_json_error( $this->errors );
+		}
+		else {
+			wp_send_json_success(  );
+		}
+
+		/*foreach( $this->errors as $error ) {
+			foreach( $error as $element_name => $element_error ) {
+				$kk = '';
+
+			}
+		}*/
 	}
 
 	/**

--- a/classes/WP_Form_Submission.php
+++ b/classes/WP_Form_Submission.php
@@ -97,20 +97,13 @@ class WP_Form_Submission {
 	}
 
 	public function send_ajax_answer() {
-		$kk = '';
+		$elements = $this->form->get_elements_as_array();
 		if ( !$this->is_valid() ) {
-			wp_send_json_error( $this->errors );
+			wp_send_json_error( $elements );
 		}
 		else {
-			wp_send_json_success(  );
+			wp_send_json_success( $elements );
 		}
-
-		/*foreach( $this->errors as $error ) {
-			foreach( $error as $element_name => $element_error ) {
-				$kk = '';
-
-			}
-		}*/
 	}
 
 	/**

--- a/classes/elements/WP_Form_Element.php
+++ b/classes/elements/WP_Form_Element.php
@@ -21,6 +21,7 @@ class WP_Form_Element implements WP_Form_Component, WP_Form_Attributes_Interface
 	protected $value = '';
 	protected $description = '';
 	protected $errors = array();
+	protected $content = '';
 
 	/** @var WP_Form_Attributes_Interface */
 	protected $attributes = NULL;
@@ -194,6 +195,15 @@ class WP_Form_Element implements WP_Form_Component, WP_Form_Attributes_Interface
 	public function clear_errors() {
 		$this->errors = array();
 		return $this;
+	}
+
+	public function set_content( $content ) {
+		$this->content = $content;
+		return $this;
+	}
+
+	public function get_content() {
+		return $this->content;
 	}
 
 	/**

--- a/classes/elements/WP_Form_Element_Checkboxes.php
+++ b/classes/elements/WP_Form_Element_Checkboxes.php
@@ -3,4 +3,11 @@
 class WP_Form_Element_Checkboxes extends WP_Form_Element_Multiple {
 	protected $type = 'checkboxes';
 	protected $default_view = 'WP_Form_View_Checkboxes';
+
+	public function get_selected() {
+		if ( !empty($this->value) ) {
+			return $this->value;
+		}
+		return $this->default_value;
+	}
 }

--- a/classes/elements/WP_Form_Element_Markup.php
+++ b/classes/elements/WP_Form_Element_Markup.php
@@ -1,0 +1,7 @@
+<?php
+
+class WP_Form_Element_Markup extends WP_Form_Element {
+	protected $type = 'markup';
+	protected $default_view = 'WP_Form_View_Markup';
+	protected $default_decorators = array();
+}

--- a/classes/elements/WP_Form_Element_Wrapper.php
+++ b/classes/elements/WP_Form_Element_Wrapper.php
@@ -1,0 +1,81 @@
+<?php
+
+/**
+ * Class WP_Form_Element_Fieldset
+ */
+class WP_Form_Element_Wrapper extends WP_Form_Element implements WP_Form_Aggregate {
+	protected $type = 'wrapper';
+	protected $default_view = 'WP_Form_View_Wrapper';
+	protected $default_decorators = array();
+
+	/** @var WP_Form_Component[] */
+	protected $elements = array();
+
+	/**
+	 * Add a child component
+	 *
+	 * @param WP_Form_Component $element
+	 * @param string $key A unique key for the component.
+	 *                    Any existing component with the same key
+	 *                    will be overwritten. If $key is empty,
+	 *                    an attempt will be made to generate a
+	 *                    unique key.
+	 * @throws InvalidArgumentException
+	 * @return $this
+	 */
+	public function add_element( WP_Form_Component $element, $key = '' ) {
+		if ( empty($key) ) {
+			$key = $element->get_name();
+		}
+		if ( empty($key) ) {
+			throw new InvalidArgumentException(__('Cannot add nameless element to a wrapper', 'wp-forms'));
+		}
+		$this->elements[$key] = $element;
+		return $this;
+	}
+
+	/**
+	 * Remove a child component
+	 *
+	 * @param string $key
+	 * @return $this
+	 */
+	public function remove_element( $key ) {
+		if ( isset($this->elements[$key]) ) {
+			unset($this->elements[$key]);
+		}
+		return $this;
+	}
+
+	/**
+	 * Get the element with the given key
+	 *
+	 * @param string $key
+	 *
+	 * @return WP_Form_Component|NULL
+	 */
+	public function get_element( $key ) {
+		if ( !empty($this->elements[$key]) ) {
+			return $this->elements[$key];
+		}
+		foreach ( $this->elements as $e ) {
+			if ( $e instanceof WP_Form_Aggregate ) {
+				$child = $e->get_element($key);
+				if ( !empty($child) ) {
+					return $child;
+				}
+			}
+		}
+		return NULL;
+	}
+
+	/**
+	 * Get an array of all child components, sorted by priority.
+	 *
+	 * @return WP_Form_Component[]
+	 */
+	public function get_children() {
+		$elements = WP_Form_Element::sort_elements($this->elements);
+		return $elements;
+	}
+}

--- a/classes/views/WP_Form_View_Checkboxes.php
+++ b/classes/views/WP_Form_View_Checkboxes.php
@@ -7,14 +7,19 @@ class WP_Form_View_Checkboxes extends WP_Form_View {
 			throw new LogicException(__('Cannot render checkbox group without a name', 'wp-forms'));
 		}
 		$options = $element->get_options();
+		$selected = (array) $element->get_selected();
 		$output = '';
 		foreach ( $options as $key => $label ) {
-			$output .= $this->checkbox( $key, $label, $attributes );
+			$checked = false;
+			if ( in_array( $key, $selected ) ) {
+				$checked = true;
+			}
+			$output .= $this->checkbox( $key, $label, $attributes, $checked );
 		}
 		return $output;
 	}
 
-	protected function checkbox( $key, $label, $attributes ) {
+	protected function checkbox( $key, $label, $attributes, $checked ) {
 		$checkbox = WP_Form_Element::create('checkbox')
 			->set_name($attributes['name'].'[]')
 			->set_label($label)
@@ -31,6 +36,9 @@ class WP_Form_View_Checkboxes extends WP_Form_View {
 		}
 		foreach ( $attributes as $att => $value ) {
 			$checkbox->set_attribute($att, $value);
+		}
+		if( $checked ) {
+			$checkbox->set_attribute( 'checked', 'checked' );
 		}
 		do_action('wp_form_checkbox_group_member', $checkbox);
 		return $checkbox->render();

--- a/classes/views/WP_Form_View_Markup.php
+++ b/classes/views/WP_Form_View_Markup.php
@@ -12,7 +12,7 @@ class WP_Form_View_Markup extends WP_Form_View {
 	}
 
 	protected function markup( WP_Form_Element $element ) {
-		$value = $element->get_value();
+		$content = $element->get_content();
 
 		$attributes = $element->get_all_attributes();
 
@@ -20,7 +20,7 @@ class WP_Form_View_Markup extends WP_Form_View {
 		$attributes = WP_Form_View::prepare_attributes($attributes);
 
 		$template = '<div %s>%s</div>';
-		return sprintf( $template, $attributes, $value );
+		return sprintf( $template, $attributes, $content );
 	}
 
 }

--- a/classes/views/WP_Form_View_Markup.php
+++ b/classes/views/WP_Form_View_Markup.php
@@ -1,0 +1,26 @@
+<?php
+
+class WP_Form_View_Markup extends WP_Form_View {
+	public function render( WP_Form_Component $element ) {
+		$type = $element->get_type();
+		if ( method_exists( $this, $type ) ) {
+			return call_user_func( array( $this, $type ), $element );
+		} elseif ( $element instanceof WP_Form_Element ) {
+			return $this->markup($element); // fallback to generic <input />
+		}
+		return '';
+	}
+
+	protected function markup( WP_Form_Element $element ) {
+		$value = $element->get_value();
+
+		$attributes = $element->get_all_attributes();
+
+		unset($attributes['value'], $attributes['type']);
+		$attributes = WP_Form_View::prepare_attributes($attributes);
+
+		$template = '<div %s>%s</div>';
+		return sprintf( $template, $attributes, $value );
+	}
+
+}

--- a/classes/views/WP_Form_View_Textarea.php
+++ b/classes/views/WP_Form_View_Textarea.php
@@ -15,7 +15,7 @@ class WP_Form_View_Textarea extends WP_Form_View {
 		$attributes = $element->get_all_attributes();
 		$value = '';
 		if ( isset($attributes['value']) ) {
-			$value = $attributes['value'];
+			$value = esc_textarea( $attributes['value'] );
 			unset($attributes['value']);
 		}
 		$attributes = WP_Form_View::prepare_attributes($attributes);

--- a/classes/views/WP_Form_View_Wrapper.php
+++ b/classes/views/WP_Form_View_Wrapper.php
@@ -1,0 +1,60 @@
+<?php
+
+/**
+ * Class WP_Form_View_Fieldset
+ */
+class WP_Form_View_Wrapper extends WP_Form_View {
+	public function render( WP_Form_Component $element ) {
+		$type = $element->get_type();
+		if ( method_exists( $this, $type ) ) {
+			return call_user_func( array( $this, $type ), $element );
+		} elseif ( $element instanceof WP_Form_Element_Wrapper ) {
+			return $this->wrapper($element); // fallback to generic <fieldset />
+		}
+		return '';
+	}
+
+	protected function wrapper( WP_Form_Element_Wrapper $element ) {
+		$children = $this->render_children($element);
+
+		$attributes = $element->get_all_attributes();
+		// Because this is just a tag (div, span) we don't need this attrs in tag.
+		unset($attributes['name'], $attributes['tag_name'], $attributes['type'], $attributes['value']);
+		$attributes = WP_Form_View::prepare_attributes($attributes);
+
+		$tag_name = $element->get_attribute('tag_name');
+		if( empty( $tag_name ) ) {
+			$tag_name = 'div';
+		}
+		$output = sprintf(
+			'<%1$s %2$s>%3$s</%1$s>',
+			$tag_name,
+			$attributes,
+			$children
+		);
+		return $output;
+	}
+
+	/**
+	 * Walk through each child and render it
+	 *
+	 * @param WP_Form_Aggregate $fieldset
+	 * @return string
+	 */
+	protected function render_children( WP_Form_Aggregate $wrapper ) {
+		$children = '';
+		foreach ( $wrapper->get_children() as $child ) {
+			$children .= $this->render_child($child);
+		}
+		return $children;
+	}
+
+	/**
+	 * @param WP_Form_Component $element
+	 * @return string
+	 */
+	protected function render_child( WP_Form_Component $element ) {
+		return $element->render();
+	}
+
+}

--- a/classes/views/decorators/WP_Form_Decorator_Errors.php
+++ b/classes/views/decorators/WP_Form_Decorator_Errors.php
@@ -1,16 +1,42 @@
 <?php
 
 class WP_Form_Decorator_Errors extends WP_Form_Decorator {
+	const POSITION_BEFORE = 0;
+	const POSITION_AFTER = 1;
+
 	public function render( WP_Form_Component $element ) {
 		$errors = $element->get_errors();
 		$output = '';
 		if ( $errors ) {
-			$output = '<ul class="errors">';
-			foreach ( $errors as $e ) {
-				$output .= '<li class="error">'.$e.'</li>';
+			$args = wp_parse_args(
+				$this->args,
+				array(
+					'tag' => 'ul',
+					'tag_single' => 'li',
+					'class_single' => 'error',
+					'attributes' => array(),
+					'position' => self::POSITION_AFTER
+				)
+			);
+
+			$output = '<' . $args['tag'] . ' ' . WP_Form_View::prepare_attributes( $args['attributes'] ) . '>';
+			foreach ( $errors as $error ) {
+				$output .= '<' . $args['tag_single'] . ' class="' . $args['class_single']. '">' . $error . '</' . $args['tag_single'] . '>';
 			}
-			$output .= '</ul>';
+			$output .= '</' . $args['tag'] . '>';
+
+			switch ( $args['position'] ) {
+				case self::POSITION_AFTER:
+					return $this->component_view->render($element) . $output;
+					break;
+
+				case self::POSITION_BEFORE:
+				default:
+					return $output . $this->component_view->render($element);
+					break;
+			}
+
+
 		}
-		return $output . $this->component_view->render($element);
 	}
 }

--- a/classes/views/decorators/WP_Form_Decorator_Errors.php
+++ b/classes/views/decorators/WP_Form_Decorator_Errors.php
@@ -6,8 +6,8 @@ class WP_Form_Decorator_Errors extends WP_Form_Decorator {
 
 	public function render( WP_Form_Component $element ) {
 		$errors = $element->get_errors();
-		$output = '';
 		if ( $errors ) {
+			$output = '';
 			$args = wp_parse_args(
 				$this->args,
 				array(
@@ -19,11 +19,15 @@ class WP_Form_Decorator_Errors extends WP_Form_Decorator {
 				)
 			);
 
-			$output = '<' . $args['tag'] . ' ' . WP_Form_View::prepare_attributes( $args['attributes'] ) . '>';
 			foreach ( $errors as $error ) {
 				$output .= '<' . $args['tag_single'] . ' class="' . $args['class_single']. '">' . $error . '</' . $args['tag_single'] . '>';
 			}
-			$output .= '</' . $args['tag'] . '>';
+			$output = sprintf(
+				'<%1$s %2$s>%3$s</%1$s>',
+				$args['tag'],
+				WP_Form_View::prepare_attributes( $args['attributes'] ),
+				$output
+			);
 
 			switch ( $args['position'] ) {
 				case self::POSITION_AFTER:
@@ -35,8 +39,8 @@ class WP_Form_Decorator_Errors extends WP_Form_Decorator {
 					return $output . $this->component_view->render($element);
 					break;
 			}
-
-
 		}
+
+		return $this->component_view->render($element);
 	}
 }

--- a/wp-forms.php
+++ b/wp-forms.php
@@ -5,7 +5,7 @@ Plugin URI: https://github.com/jbrinley/wp-forms
 Description: An API for creating, altering, validating, and submitting forms via code.
 Author: Flightless
 Author URI: http://flightless.us/
-Version: 0.4
+Version: 0.4.1
 */
 /*
 Copyright (c) 2013 Flightless, Inc. http://flightless.us/

--- a/wp-forms.php
+++ b/wp-forms.php
@@ -5,7 +5,7 @@ Plugin URI: https://github.com/jbrinley/wp-forms
 Description: An API for creating, altering, validating, and submitting forms via code.
 Author: Flightless
 Author URI: http://flightless.us/
-Version: 0.5
+Version: 0.5.1
 */
 /*
 Copyright (c) 2013 Flightless, Inc. http://flightless.us/

--- a/wp-forms.php
+++ b/wp-forms.php
@@ -5,7 +5,7 @@ Plugin URI: https://github.com/jbrinley/wp-forms
 Description: An API for creating, altering, validating, and submitting forms via code.
 Author: Flightless
 Author URI: http://flightless.us/
-Version: 0.4.1
+Version: 0.4.1.1
 */
 /*
 Copyright (c) 2013 Flightless, Inc. http://flightless.us/

--- a/wp-forms.php
+++ b/wp-forms.php
@@ -5,7 +5,7 @@ Plugin URI: https://github.com/jbrinley/wp-forms
 Description: An API for creating, altering, validating, and submitting forms via code.
 Author: Flightless
 Author URI: http://flightless.us/
-Version: 0.4.1.1
+Version: 0.5
 */
 /*
 Copyright (c) 2013 Flightless, Inc. http://flightless.us/


### PR DESCRIPTION
Sometimes we need a wrapper for some stuff inside the form (not a `<fieldset>` tag). For example — Input Groups from Bootrap needs a `<div class="input-group">` wrapper. For this I've create Wrapper component. See [getbootstrap.com/components/#input-groups-buttons](http://getbootstrap.com/components/#input-groups-buttons).

**Errors decorator**
Now this decorator can put errors at the bottom of input and also opportunity for change tags and classes.
